### PR TITLE
MVC widgets bug fixes

### DIFF
--- a/Ucommerce.Sitefinity.UI/Constants/RouteConstants.cs
+++ b/Ucommerce.Sitefinity.UI/Constants/RouteConstants.cs
@@ -5,25 +5,27 @@
     /// </summary>
     internal class RouteConstants
     {
+        public const string ROUTE_PREFIX = "storeapi";
+
         public const string SEARCH_ROUTE_NAME = "productSearchUrl";
-        public const string SEARCH_ROUTE_VALUE = "search/full-text";
+        public const string SEARCH_ROUTE_VALUE = ROUTE_PREFIX + "/search/full-text";
 
         public const string SEARCH_SUGGESTIONS_ROUTE_NAME = "searchSuggestionsUrl";
-        public const string SEARCH_SUGGESTIONS_ROUTE_VALUE = "search/suggestions";
+        public const string SEARCH_SUGGESTIONS_ROUTE_VALUE = ROUTE_PREFIX + "/search/suggestions";
 
         public const string PRICE_GROUP_ROUTE_NAME = "changePriceGroupUrl";
-        public const string PRICE_GROUP_ROUTE_VALUE = "basket/price-group";
+        public const string PRICE_GROUP_ROUTE_VALUE = ROUTE_PREFIX + "/price-group";
 
         public const string ADD_TO_BASKET_ROUTE_NAME = "addToBasketUrl";
-        public const string ADD_TO_BASKET_ROUTE_VALUE = "basket/add";
+        public const string ADD_TO_BASKET_ROUTE_VALUE = ROUTE_PREFIX + "/basket/add";
 
         public const string UPDATE_LINE_ITEM_ROUTE_NAME = "updateLineItemUrl";
-        public const string UPDATE_LINE_ITEM_ROUTE_VALUE = "basket/line-item";
+        public const string UPDATE_LINE_ITEM_ROUTE_VALUE = ROUTE_PREFIX + "/basket/line-item";
 
         public const string ADD_VOUCHER_ROUTE_NAME = "addVoucherUrl";
-        public const string ADD_VOUCHER_ROUTE_VALUE = "basket/voucher";
+        public const string ADD_VOUCHER_ROUTE_VALUE = ROUTE_PREFIX + "/basket/voucher";
 
         public const string GET_BASKET_ROUTE_NAME = "getBasketUrl";
-        public const string GET_BASKET_ROUTE_VALUE = "basket/get";
+        public const string GET_BASKET_ROUTE_VALUE = ROUTE_PREFIX + "/basket/get";
     }
 }

--- a/Ucommerce.Sitefinity.UI/Mvc/Model/PaymentPickerModel.cs
+++ b/Ucommerce.Sitefinity.UI/Mvc/Model/PaymentPickerModel.cs
@@ -32,7 +32,8 @@ namespace UCommerce.Sitefinity.UI.Mvc.Model
             var paymentPickerViewModel = new PaymentPickerViewModel();
 
             var basket = _transactionLibraryInternal.GetBasket().PurchaseOrder;
-            var shippingCountry = UCommerce.Api.TransactionLibrary.GetCountries().SingleOrDefault(x => x.Name == "Germany");
+            var shippingCountry = basket.GetShippingAddress(UCommerce.Constants.DefaultShipmentAddressName).Country;
+                //UCommerce.Api.TransactionLibrary.GetCountries().SingleOrDefault(x => x.Name == "Germany");
 
             paymentPickerViewModel.ShippingCountry = shippingCountry.Name;
 

--- a/Ucommerce.Sitefinity.UI/Mvc/Model/PaymentPickerModel.cs
+++ b/Ucommerce.Sitefinity.UI/Mvc/Model/PaymentPickerModel.cs
@@ -32,9 +32,12 @@ namespace UCommerce.Sitefinity.UI.Mvc.Model
             var paymentPickerViewModel = new PaymentPickerViewModel();
 
             var basket = _transactionLibraryInternal.GetBasket().PurchaseOrder;
-            var shippingCountry = basket.GetShippingAddress(UCommerce.Constants.DefaultShipmentAddressName).Country;
-                //UCommerce.Api.TransactionLibrary.GetCountries().SingleOrDefault(x => x.Name == "Germany");
 
+            var shippingAddress =
+                _transactionLibraryInternal.GetShippingInformation(UCommerce.Constants.DefaultShipmentAddressName);
+            
+            var shippingCountry = shippingAddress.Country;
+            
             paymentPickerViewModel.ShippingCountry = shippingCountry.Name;
 
             var availablePaymentMethods = _transactionLibraryInternal.GetPaymentMethods(shippingCountry);

--- a/Ucommerce.Sitefinity.UI/Mvc/Model/ProductModel.cs
+++ b/Ucommerce.Sitefinity.UI/Mvc/Model/ProductModel.cs
@@ -2,7 +2,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Web;
+using System.Windows.Forms;
 using Telerik.Sitefinity;
 using Telerik.Sitefinity.Services;
 using Telerik.Sitefinity.Web;
@@ -14,7 +16,9 @@ using UCommerce;
 using UCommerce.Api;
 using UCommerce.Content;
 using UCommerce.EntitiesV2;
+using UCommerce.EntitiesV2.Definitions;
 using UCommerce.Extensions;
+using UCommerce.Infrastructure.Globalization;
 using UCommerce.Runtime;
 using UCommerce.Search;
 
@@ -147,22 +151,15 @@ namespace UCommerce.Sitefinity.UI.Mvc.Model
                     productDetailViewModel.ProductUrl = CatalogLibrary.GetNiceUrlForProduct(currentProduct, currentCategory);
                 }
 
+                var invariantFields = currentProduct.ProductProperties;
 
-                foreach (var pv in currentProduct.Variants)
-                {
-                    foreach (var v in pv.ProductProperties)
-                    {
-                        if (v.ProductDefinitionField != null && v.ProductDefinitionField.IsVariantProperty)
-                        {
-                            if (productDetailViewModel.VariantTypes.Any(t => t.Id == v.ProductDefinitionField.Id))
-                            {
-
-                            }
-                        }
-                    }
-                }
-
-
+                var localizationContext = Infrastructure.ObjectFactory.Instance.Resolve<ILocalizationContext>();
+                
+                var fieldsForCurrentLanguage = currentProduct.GetProperties(localizationContext.CurrentCultureCode).ToList();
+                
+                productDetailViewModel.ProductProperties = invariantFields.Concat(fieldsForCurrentLanguage).ToList();
+                
+                
                 var uniqueVariants = from v in currentProduct.Variants.SelectMany(p => p.ProductProperties)
                                      where v.ProductDefinitionField.DisplayOnSite
                                      group v by v.ProductDefinitionField into g

--- a/Ucommerce.Sitefinity.UI/Mvc/ViewModels/ConfirmationEmailViewModel.cs
+++ b/Ucommerce.Sitefinity.UI/Mvc/ViewModels/ConfirmationEmailViewModel.cs
@@ -4,7 +4,7 @@ using UCommerce.EntitiesV2;
 namespace UCommerce.Sitefinity.UI.Mvc.ViewModels
 {
     /// <summary>
-    /// ViewModel class used for visualizing the information assocaited with a confirmation email.
+    /// ViewModel class used for visualizing the information associated with a confirmation email.
     /// </summary>
     public class ConfirmationEmailViewModel
     {

--- a/Ucommerce.Sitefinity.UI/Mvc/ViewModels/ConfirmationMessageViewModel.cs
+++ b/Ucommerce.Sitefinity.UI/Mvc/ViewModels/ConfirmationMessageViewModel.cs
@@ -1,7 +1,7 @@
 ﻿namespace UCommerce.Sitefinity.UI.Mvc.ViewModels
 {
     /// <summary>
-    /// ViewModel class used for visualizing the information assocaited with a confirmation message.
+    /// ViewModel class used for visualizing the information associated with a confirmation message.
     /// </summary>
     public class ConfirmationMessageViewModel
     {

--- a/Ucommerce.Sitefinity.UI/Mvc/ViewModels/FacetViewModel.cs
+++ b/Ucommerce.Sitefinity.UI/Mvc/ViewModels/FacetViewModel.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace UCommerce.Sitefinity.UI.Mvc.ViewModels
 {
     /// <summary>
-    /// ViewModel class used for visualizing the information assocaited with facets.
+    /// ViewModel class used for visualizing the information associated with facets.
     /// </summary>
     public class FacetViewModel
     {

--- a/Ucommerce.Sitefinity.UI/Mvc/ViewModels/MiniBasketRefreshViewModel.cs
+++ b/Ucommerce.Sitefinity.UI/Mvc/ViewModels/MiniBasketRefreshViewModel.cs
@@ -1,7 +1,7 @@
 ﻿namespace UCommerce.Sitefinity.UI.Mvc.ViewModels
 {
     /// <summary>
-    /// ViewModel class used for visualizing the information assocaited with the mini basket after refresh.
+    /// ViewModel class used for visualizing the information associated with the mini basket after refresh.
     /// </summary>
     public class MiniBasketRefreshViewModel
     {

--- a/Ucommerce.Sitefinity.UI/Mvc/ViewModels/OrderOverviewViewModel.cs
+++ b/Ucommerce.Sitefinity.UI/Mvc/ViewModels/OrderOverviewViewModel.cs
@@ -4,7 +4,7 @@ using UCommerce.EntitiesV2;
 namespace UCommerce.Sitefinity.UI.Mvc.ViewModels
 {
     /// <summary>
-    /// ViewModel class used for visualizing the information assocaited with an order.
+    /// ViewModel class used for visualizing the information associated with an order.
     /// </summary>
     public class OrderOverviewViewModel
     {

--- a/Ucommerce.Sitefinity.UI/Mvc/ViewModels/OrderlineViewModel.cs
+++ b/Ucommerce.Sitefinity.UI/Mvc/ViewModels/OrderlineViewModel.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace UCommerce.Sitefinity.UI.Mvc.ViewModels
 {
     /// <summary>
-    /// ViewModel class used for visualizing the information assocaited with an item in an order.
+    /// ViewModel class used for visualizing the information associated with an item in an order.
     /// </summary>
     public class OrderlineViewModel
     {

--- a/Ucommerce.Sitefinity.UI/Mvc/ViewModels/PreviewOrderLine.cs
+++ b/Ucommerce.Sitefinity.UI/Mvc/ViewModels/PreviewOrderLine.cs
@@ -1,7 +1,7 @@
 ﻿namespace UCommerce.Sitefinity.UI.Mvc.ViewModels
 {
     /// <summary>
-    /// DTO class used for storing the information assocaited with an item in an order.
+    /// DTO class used for storing the information associated with an item in an order.
     /// </summary>
     public class PreviewOrderLine
     {

--- a/Ucommerce.Sitefinity.UI/Mvc/ViewModels/ProductDTO.cs
+++ b/Ucommerce.Sitefinity.UI/Mvc/ViewModels/ProductDTO.cs
@@ -1,7 +1,7 @@
 ﻿namespace UCommerce.Sitefinity.UI.Mvc.ViewModels
 {
     /// <summary>
-    /// DTO class used for storing the information assocaited with a product.
+    /// DTO class used for storing the information associated with a product.
     /// </summary>
     public class ProductDTO
     {

--- a/Ucommerce.Sitefinity.UI/Mvc/ViewModels/ProductDetailViewModel.cs
+++ b/Ucommerce.Sitefinity.UI/Mvc/ViewModels/ProductDetailViewModel.cs
@@ -1,18 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
 using UCommerce.EntitiesV2;
+using UCommerce.EntitiesV2.Definitions;
 
 namespace UCommerce.Sitefinity.UI.Mvc.ViewModels
 {
     /// <summary>
-    /// ViewModel class used for visualizing the detailed information assocaited with a product.
+    /// ViewModel class used for visualizing the detailed information associated with a product.
     /// </summary>
     public class ProductDetailViewModel
     {
         public ProductDetailViewModel()
         {
-            this.VariantTypes = new List<VariantTypeViewModel>();
-            this.Routes = new Dictionary<string, string>();
+            VariantTypes = new List<VariantTypeViewModel>();
+            Routes = new Dictionary<string, string>();
+            ProductProperties = new List<IProperty>();
         }
 
         public string DisplayName { get; set; }
@@ -59,6 +61,6 @@ namespace UCommerce.Sitefinity.UI.Mvc.ViewModels
 
         public Dictionary<string, string> Routes { get; set; }
 
-        public ICollection<ProductProperty> ProductProperties { get; internal set; }
+        public IList<IProperty> ProductProperties { get; set; }
     }
 }

--- a/Ucommerce.Sitefinity.UI/Mvc/ViewModels/ProductListViewModel.cs
+++ b/Ucommerce.Sitefinity.UI/Mvc/ViewModels/ProductListViewModel.cs
@@ -3,7 +3,7 @@
 namespace UCommerce.Sitefinity.UI.Mvc.ViewModels
 {
     /// <summary>
-    /// ViewModel class used for visualizing the information assocaited with list of products.
+    /// ViewModel class used for visualizing the information associated with list of products.
     /// </summary>
     public class ProductListViewModel
     {

--- a/Ucommerce.Sitefinity.UI/Mvc/Views/Products/List.Index.cshtml
+++ b/Ucommerce.Sitefinity.UI/Mvc/Views/Products/List.Index.cshtml
@@ -38,9 +38,9 @@
     <ul>
         @foreach (var product in Model.Products)
         {
-            <li>
+           <li>
                 <a title="@Html.HtmlSanitize((string)product.DisplayName)" href="@product.ProductUrl">
-                    <img title="Top 100 Digital Agencies" src="@product.ThumbnailImageMediaUrl" alt="@Html.HtmlSanitize((string)product.DisplayName)">
+                     <img width="200" height="200" title="Top 100 Digital Agencies" src="@product.ThumbnailImageMediaUrl" alt="@Html.HtmlSanitize((string)product.DisplayName)"> 
                 </a>
 
                 <a href="@product.ProductUrl">@Html.HtmlSanitize((string)product.DisplayName)</a>
@@ -50,11 +50,15 @@
                     <p>Discount:</p>
                     <span>@product.Discount</span>
                 </div>
-
-                <add-to-basket :product-sku="'@product.Sku'" :root-id="$el.id">
-                </add-to-basket>
-
+                
+                @if (product.IsSellableProduct)
+                {
+                    <add-to-basket :product-sku="'@product.Sku'" :root-id="$el.id">
+                    </add-to-basket>
+                }
             </li>
+            
+            
         }
     </ul>
 

--- a/Ucommerce.Sitefinity.UI/Ucommerce.Sitefinity.UI.csproj
+++ b/Ucommerce.Sitefinity.UI/Ucommerce.Sitefinity.UI.csproj
@@ -547,6 +547,9 @@
     <EmbeddedResource Include="assets\src\images\icons\products.png" />
     <EmbeddedResource Include="assets\src\images\icons\shipping-picker.png" />
     <EmbeddedResource Include="Mvc\Scripts\Products\designerview-simple.js" />
+    <Content Include="..\release notes.txt">
+      <Link>docs\release notes.txt</Link>
+    </Content>
     <Content Include="Mvc\Views\Shared\readme.txt" />
     <EmbeddedResource Include="Mvc\Views\Shared\_Warning.cshtml" />
     <None Include="node_modules\%40babel\cli\LICENSE" />

--- a/Ucommerce.Sitefinity.UI/assets/src/js/components/add-to-basket.vue
+++ b/Ucommerce.Sitefinity.UI/assets/src/js/components/add-to-basket.vue
@@ -51,7 +51,7 @@
                             this.showAddToBasketMessage = true;
 
 							var isEmpty = !(response.data.NumberOfItemsInBasket > 0);
-                            var miniBasketRefresh = { NumberOfItems: response.data.NumberOfItemsInBasket, Total: response.data.PaymentTotal, IsEmpty: isEmpty };
+                            var miniBasketRefresh = { NumberOfItems: response.data.NumberOfItemsInBasket, Total: response.data.OrderTotal, IsEmpty: isEmpty };
 
 							$(document).find('.js-mini-basket').each(function () {
 

--- a/release notes.txt
+++ b/release notes.txt
@@ -1,0 +1,8 @@
+Change log for vNext
+
+Fix: ProductViewModel now has access to product properties  
+Fix: "Add to basket" button only appears for parent products at the category level
+Fix: PaymentPicker widget only displays payment providers available for the selected shipping country
+Fix: Mini Basket now updates the price when adding new products
+Fix: Added "storeapi" route prefix to not clash with other CMS pages
+


### PR DESCRIPTION
Fix: ProductViewModel now has access to product properties  
Fix: "Add to basket" button only appears for parent products at the category level
Fix: PaymentPicker widget only displays payment providers available for the selected shipping country
Fix: Mini Basket now updates the price when adding new products
Fix: Added "storeapi" route prefix to not clash with other CMS pages