### PR TITLE
fix: bundling conflict between widgets and sitefinity

### DIFF
--- a/Ucommerce.Sitefinity.UI/App_Start/Startup.cs
+++ b/Ucommerce.Sitefinity.UI/App_Start/Startup.cs
@@ -51,9 +51,6 @@ namespace UCommerce.Sitefinity.UI.App_Start
             //Custom resources
             Res.RegisterResource<UcommerceResources>();
 
-            BundleTable.VirtualPathProvider = HostingEnvironment.VirtualPathProvider;
-            BundleTable.EnableOptimizations = true;
-
             ObjectFactory.Container.RegisterType<PageEditorRouteHandler, UCommerceMvcPageEditorRouteHandler>();
             ObjectFactory.Container.RegisterType<TemplateEditorRouteHandler, UCommerceMvcTemplateEditorRouteHandler>();
         }


### PR DESCRIPTION
In previous versions,microsoft's bundling was used to serve all the javascript content that was needed.
https://github.com/Ucommercenet/Ucommerce.Sitefinity.UI/commit/1aedacd196cebd458a66e43ecb44034df6614ed7

The usages of the bundles, however, were removed when the javascript content was updated, but the bundling configuration was forgotten.
https://github.com/Ucommercenet/Ucommerce.Sitefinity.UI/commit/ee20361d8f0dc54344f440909a6feaee381287b5

The configuration also affects the setup of Sitefinity's own bundles. https://www.progress.com/documentation/sitefinity-cms/administration-enable-asp-net-bundling-and-minification

After identifying the cause of the issue, the two lines were removed, and as they were no longer in use, no functionality was affected. 