### PR TITLE
Compatibility with upcoming Ucommerce 9.4 syntax changes

### DIFF
--- a/Ucommerce.Sitefinity.UI/Mvc/Model/ProductModel.cs
+++ b/Ucommerce.Sitefinity.UI/Mvc/Model/ProductModel.cs
@@ -439,7 +439,6 @@ namespace UCommerce.Sitefinity.UI.Mvc.Model
 			if (facets.Count > 0)
 			{
 				matchingProducts.Where(facets.ToFacetDictionary());
-				matchingProducts.PriceGroup(CatalogContext.CurrentPriceGroup.Name);
 			}
 
 			if (currentCategory != null)

--- a/Ucommerce.Sitefinity.UI/Ucommerce.Sitefinity.UI.csproj
+++ b/Ucommerce.Sitefinity.UI/Ucommerce.Sitefinity.UI.csproj
@@ -58,6 +58,10 @@
     <Reference Include="Dapper, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Dapper.2.0.30\lib\net461\Dapper.dll</HintPath>
     </Reference>
+    <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d">
+      <HintPath>..\packages\Elasticsearch.Net.7.6.2\lib\net461\Elasticsearch.Net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="EPPlus, Version=4.1.1.0, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
       <HintPath>..\packages\EPPlus.4.1.1\lib\net40\EPPlus.dll</HintPath>
     </Reference>
@@ -84,6 +88,12 @@
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Ucommerce.Sitefinity.9.3.1.20275\lib\Microsoft.Web.XmlTransform.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d">
+      <HintPath>..\packages\NEST.7.6.2\lib\net461\Nest.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -116,6 +126,10 @@
       <HintPath>..\packages\Slugify.Core.2.3.0\lib\net40\Slugify.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ComponentModel.Annotations.4.4.1\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
     </Reference>
@@ -123,6 +137,10 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Linq.Dynamic, Version=1.0.6132.35681, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Linq.Dynamic.1.0.7\lib\net40\System.Linq.Dynamic.dll</HintPath>

--- a/Ucommerce.Sitefinity.UI/packages.config
+++ b/Ucommerce.Sitefinity.UI/packages.config
@@ -10,6 +10,7 @@
   <package id="ClientDependency" version="1.9.7" targetFramework="net472" />
   <package id="Dapper" version="2.0.30" targetFramework="net472" />
   <package id="EPPlus" version="4.1.1" targetFramework="net472" />
+  <package id="Elasticsearch.Net" version="7.6.2" targetFramework="net472" />
   <package id="FluentNHibernate" version="2.1.2" targetFramework="net472" />
   <package id="FluentValidation" version="8.4.0" targetFramework="net472" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net472" />
@@ -21,8 +22,10 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.6.0" targetFramework="net472" />
   <package id="Microsoft.CompilerServices.AsyncTargetingPack" version="1.0.1" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
+  <package id="NEST" version="7.6.2" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net472" />
   <package id="NHibernate" version="5.2.5" targetFramework="net472" />
   <package id="NHibernate.Caches.SysCache" version="5.5.1" targetFramework="net472" />
@@ -33,7 +36,9 @@
   <package id="Remotion.Linq.EagerFetching" version="2.2.0" targetFramework="net472" />
   <package id="Sitefinity.RazorEngine" version="3.0.8.0" targetFramework="net472" />
   <package id="Slugify.Core" version="2.3.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net472" />
   <package id="System.ComponentModel.Annotations" version="4.4.1" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net472" />
   <package id="System.Linq.Dynamic" version="1.0.7" targetFramework="net472" />
   <package id="Telerik.DataAccess.Core" version="2020.0.428.1" targetFramework="net472" />
   <package id="Telerik.Sitefinity.Core" version="13.1.7400" targetFramework="net472" />


### PR DESCRIPTION
Problem A: SF also uses NEST and ES nuget deps, but with a fixed version that differs between SF 11 and 12.
Solution: Don't declare our dependency in our nuspec, but ship our version and sideload from apps/Ucommerce.Search.Elasticsearch/bin. This requires that our IoC config files reference our specific version of NEST.dll.

Problem B: Various incompatible dependencies such as Castle.Core and others prevented installation of Ucommerce.Sitefinity.
Solution B: Relaxed some of the version constraints we had.

PR for main repo: https://github.com/Ucommercenet/Ucommerce/pull/620