### PR TITLE
BugFix: Remove hardcoded title from product image

### DIFF
--- a/ResourcePackages/Bootstrap4/MVC/Views/Products/List.Index.cshtml
+++ b/ResourcePackages/Bootstrap4/MVC/Views/Products/List.Index.cshtml
@@ -55,7 +55,7 @@
                                     <div class="card-body p-0 p-2">
 
                                         <a title="@product.DisplayName" href="@product.ProductUrl">
-                                            <img title="Top 100 Digital Agencies" class="card-img-top img-thumbnail" src="@product.ThumbnailImageMediaUrl" alt="@product.DisplayName">
+                                            <img title="@product.DisplayName" class="card-img-top img-thumbnail" src="@product.ThumbnailImageMediaUrl" alt="@product.DisplayName">
                                         </a>
 
                                         <h5 class="card-title mt-2">


### PR DESCRIPTION
the <img title tag was hardcoded to "Top 100 Digital Agencies"